### PR TITLE
Build static library for WIN32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ language: C
 
 # Try using multiple Lua Implementations
 env:
-  - TOOL=""                     # Use native compiler (GCC usually)
-  - COMPILER="clang"            # Use clang
-# - COMPILER="fortran"          # Use fortran, make sure to modify the matrix section
+  - TOOL="gcc"                  # Use native compiler (GCC usually)
+  - TOOL="clang"                # Use clang
   - TOOL="i686-w64-mingw32"     # 32bit MinGW
   - TOOL="x86_64-w64-mingw32"   # 64bit MinGW
   - TOOL="arm-linux-gnueabihf"  # ARM hard-float (hf), linux
@@ -20,23 +19,23 @@ matrix:
     - env: TOOL="i686-w64-mingw32"
     - env: TOOL="x86_64-w64-mingw32"
     - env: TOOL="arm-linux-gnueabihf"
-  
+
 # Install dependencies
 install:
-  - git clone git://github.com/LuaDist/_util.git ~/_util
-  - ~/_util/travis install
+  - git clone git://github.com/LuaDist/Tools.git ~/_tools
+  - ~/_tools/travis/travis install
 
 # Bootstap
 before_script:
-  - ~/_util/travis bootstrap
+  - ~/_tools/travis/travis bootstrap
 
 # Build the module
 script:
-  - ~/_util/travis build
+  - ~/_tools/travis/travis build
 
 # Execute additional tests or commands
-#after_script:
-#  - ~/_util/travis test
+after_script:
+  - ~/_tools/travis/travis test
 
 # Only watch the master branch
 branches:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ set ( SRC jmemnobs.c jaricom.c jcapimin.c jcapistd.c jcarith.c jccoefct.c jccolo
 
 if ( WIN32 )
   add_library ( jpeg STATIC ${SRC} ${HEADERS} )
-else
+else ( WIN32 )
   add_library ( jpeg ${SRC} ${HEADERS} )
-endif ( )
+endif ( WIN32 )
 
 add_executable ( cjpeg cdjpeg.c cjpeg.c rdbmp.c rdgif.c rdppm.c rdrle.c rdtarga.c 
   rdswitch.c )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,11 @@ set ( SRC jmemnobs.c jaricom.c jcapimin.c jcapistd.c jcarith.c jccoefct.c jccolo
   jidctflt.c jidctfst.c jidctint.c jquant1.c jquant2.c jutils.c jmemmgr.c cderror.h 
   cdjpeg.h jdct.h jinclude.h jmemsys.h jpegint.h jversion.h transupp.h )
 
-add_library ( jpeg ${SRC} ${HEADERS} )
+if ( WIN32 )
+  add_library ( jpeg STATIC ${SRC} ${HEADERS} )
+else
+  add_library ( jpeg ${SRC} ${HEADERS} )
+endif ( )
 
 add_executable ( cjpeg cdjpeg.c cjpeg.c rdbmp.c rdgif.c rdppm.c rdrle.c rdtarga.c 
   rdswitch.c )


### PR DESCRIPTION
In WIN32 the current branch will build a dll file, but not a usable one. JPEG source files are not designed to be built as a dll on windows, so no symbols will be exported. I tried building a DLL and did not get a .lib file. So I think static library is the only option.
